### PR TITLE
Add dashboard role switch buttons

### DIFF
--- a/pages/BuyerDashboard.tsx
+++ b/pages/BuyerDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Product, Order } from '../types';
+import { Product, Order, Role } from '../types';
 import {
     getProducts,
     getOrdersByBuyer,
@@ -8,11 +8,14 @@ import {
     getProductById,
 } from '../services/firestore';
 import { useAuth } from '../contexts/AuthContext';
+import { useDashboard } from '../contexts/DashboardContext';
 import ProductCard from '../components/ProductCard';
-import { Search, X, ShoppingBag } from 'lucide-react';
+import Button from '../components/Button';
+import { Search, Repeat } from 'lucide-react';
 
 const BuyerDashboard: React.FC = () => {
     const { user } = useAuth();
+    const { setCurrentDashboard } = useDashboard();
     const [products, setProducts] = useState<Product[]>([]);
     const [orders, setOrders] = useState<Order[]>([]);
     const [loading, setLoading] = useState(true);
@@ -161,8 +164,21 @@ const BuyerDashboard: React.FC = () => {
     return (
         <div>
             <div className="mb-6">
-                <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
-                <p className="text-lg text-gray-600">Discover and purchase amazing products.</p>
+                <div className="flex justify-between items-center">
+                    <div>
+                        <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
+                        <p className="text-lg text-gray-600">Discover and purchase amazing products.</p>
+                    </div>
+                    {user?.roles.includes(Role.SELLER) && (
+                        <Button
+                            onClick={() => setCurrentDashboard('SELLER')}
+                            variant="secondary"
+                            leftIcon={<Repeat size={16} />}
+                        >
+                            Switch to Seller
+                        </Button>
+                    )}
+                </div>
             </div>
              <div className="border-b border-gray-200 mb-6">
                 <nav className="-mb-px flex space-x-8" aria-label="Tabs">

--- a/pages/SellerDashboard.tsx
+++ b/pages/SellerDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Product } from '../types';
+import { Product, Role } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import {
     getProductsBySeller,
@@ -9,10 +9,12 @@ import {
 } from '../services/firestore';
 import Button from '../components/Button';
 import Modal from '../components/Modal';
-import { Plus, Edit, Trash2 } from 'lucide-react';
+import { Plus, Edit, Trash2, Repeat } from 'lucide-react';
+import { useDashboard } from '../contexts/DashboardContext';
 
 const SellerDashboard: React.FC = () => {
     const { user } = useAuth();
+    const { setCurrentDashboard } = useDashboard();
     const [products, setProducts] = useState<Product[]>([]);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingProduct, setEditingProduct] = useState<Product | null>(null);
@@ -69,13 +71,24 @@ const SellerDashboard: React.FC = () => {
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
-                <div>
+                <div className="flex flex-col">
                   <h1 className="text-4xl font-bold text-gray-900">Seller Dashboard</h1>
                   <p className="text-lg text-gray-600">Manage your products and listings.</p>
                 </div>
-                <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}>
-                    Add New Item
-                </Button>
+                <div className="flex items-center gap-2">
+                    {user?.roles.includes(Role.BUYER) && (
+                        <Button
+                            onClick={() => setCurrentDashboard('BUYER')}
+                            variant="secondary"
+                            leftIcon={<Repeat size={16} />}
+                        >
+                            Switch to Buyer
+                        </Button>
+                    )}
+                    <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}> 
+                        Add New Item
+                    </Button>
+                </div>
             </div>
 
             <div className="bg-white shadow-sm rounded-lg">


### PR DESCRIPTION
## Summary
- enable dashboard switch from Buyer to Seller and vice versa
- show switch button in Buyer and Seller dashboards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf2809b88330b8ba86afcf9562d3