### PR TITLE
Enable default buyer and seller roles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,6 @@ import Footer from './components/Footer';
 import Modal from './components/Modal';
 import Button from './components/Button';
 import { Role } from './types';
-import { User } from './types';
 
 const App: React.FC = () => {
   return (
@@ -23,29 +22,16 @@ const App: React.FC = () => {
 };
 
 const Main: React.FC = () => {
-  const { user, isAuthenticated, loading, setUserRoles } = useAuth();
+  const { user, isAuthenticated, loading } = useAuth();
   const { currentDashboard, setCurrentDashboard } = useDashboard();
-  
-  const [showRoleSelect, setShowRoleSelect] = useState(false);
+
   const [showDashboardSelect, setShowDashboardSelect] = useState(false);
 
   useEffect(() => {
     if (isAuthenticated && user) {
-      if (user.roles.length === 0) {
-        setShowRoleSelect(true);
-      } else {
-        setShowDashboardSelect(true);
-      }
+      setShowDashboardSelect(true);
     }
   }, [isAuthenticated, user]);
-
-  const handleRoleSelection = (roles: Role[]) => {
-    if(user) {
-        setUserRoles(roles);
-        setShowRoleSelect(false);
-        setShowDashboardSelect(true);
-    }
-  };
 
   const handleDashboardSelection = (dashboard: 'BUYER' | 'SELLER') => {
     setCurrentDashboard(dashboard);
@@ -61,20 +47,6 @@ const Main: React.FC = () => {
         return <LoginPage />;
     }
 
-    if (showRoleSelect) {
-      return (
-        <Modal title="Choose Your Role" isOpen={true} onClose={() => {}}>
-          <div className="p-4 text-center">
-            <p className="mb-6 text-gray-600">Do you want to Buy, Sell, or Both?</p>
-            <div className="space-y-3">
-              <Button onClick={() => handleRoleSelection([Role.BUYER])} fullWidth>Just Buying</Button>
-              <Button onClick={() => handleRoleSelection([Role.SELLER])} fullWidth>Just Selling</Button>
-              <Button onClick={() => handleRoleSelection([Role.BUYER, Role.SELLER])} fullWidth>Both!</Button>
-            </div>
-          </div>
-        </Modal>
-      );
-    }
 
     if (showDashboardSelect) {
         return (
@@ -95,7 +67,7 @@ const Main: React.FC = () => {
 
     return currentDashboard === 'BUYER' ? <BuyerDashboard /> : <SellerDashboard />;
 
-  }, [loading, isAuthenticated, showRoleSelect, showDashboardSelect, currentDashboard, user, setUserRoles, setCurrentDashboard]);
+  }, [loading, isAuthenticated, showDashboardSelect, currentDashboard, user, setCurrentDashboard]);
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 font-sans">

--- a/services/firestore.ts
+++ b/services/firestore.ts
@@ -9,7 +9,7 @@ import {
   deleteDoc,
 } from 'firebase/firestore';
 import { firestore } from '../firebase';
-import { Product, User, Order, Cart, OrderStatus, ProductStatus, Message } from '../types';
+import { Product, User, Order, Cart, OrderStatus, ProductStatus, Message, Role } from '../types';
 
 export const getProducts = async (): Promise<Product[]> => {
   try {
@@ -105,11 +105,15 @@ export const loginUser = async (email: string): Promise<User | null> => {
         email,
         name,
         profilePicUrl: `https://i.pravatar.cc/150?u=${Date.now()}`,
-        roles: [],
+        roles: [Role.BUYER, Role.SELLER],
       });
       await updateDoc(ref, { id: ref.id });
       const snap = await getDoc(ref);
       user = snap.data() as User;
+    } else if (!user.roles || user.roles.length < 2) {
+      const updated = { ...user, roles: [Role.BUYER, Role.SELLER] };
+      await updateDoc(doc(firestore, 'users', user.id), { roles: updated.roles });
+      user = updated;
     }
     return user;
   } catch (e) {


### PR DESCRIPTION
## Summary
- ensure that new and existing users always have both buyer and seller roles
- simplify main app flow to skip role selection modal

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c83d74a88330bcc57127b7fc72e6