### PR TITLE
Remove redundant dashboard switch buttons

### DIFF
--- a/pages/BuyerDashboard.tsx
+++ b/pages/BuyerDashboard.tsx
@@ -231,15 +231,6 @@ const BuyerDashboard: React.FC = () => {
                         <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
                         <p className="text-lg text-gray-600">Discover and purchase amazing products.</p>
                     </div>
-                    {user?.roles.includes(Role.SELLER) && (
-                        <Button
-                            onClick={() => setCurrentDashboard('SELLER')}
-                            variant="secondary"
-                            leftIcon={<Repeat size={16} />}
-                        >
-                            Switch to Seller
-                        </Button>
-                    )}
                 </div>
             </div>
              <div className="border-b border-gray-200 mb-6">

--- a/pages/SellerDashboard.tsx
+++ b/pages/SellerDashboard.tsx
@@ -81,15 +81,6 @@ const SellerDashboard: React.FC = () => {
                   <p className="text-lg text-gray-600">Manage your products and listings.</p>
                 </div>
                 <div className="flex items-center gap-2">
-                    {user?.roles.includes(Role.BUYER) && (
-                        <Button
-                            onClick={() => setCurrentDashboard('BUYER')}
-                            variant="secondary"
-                            leftIcon={<Repeat size={16} />}
-                        >
-                            Switch to Buyer
-                        </Button>
-                    )}
                     <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}> 
                         Add New Item
                     </Button>


### PR DESCRIPTION
## Summary
- clean up BuyerDashboard view by removing page-level switch button
- clean up SellerDashboard view by removing page-level switch button

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639107d96483308de2cfee04d6018f