### PR TITLE
Remove cart and purchase flows

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Product, User } from '../types';
 import { getUserById } from '../services/firestore';
-import Button from './Button';
-import { ShoppingCart, DollarSign, User as UserIcon } from 'lucide-react';
+import { DollarSign, User as UserIcon } from 'lucide-react';
 
 interface ProductCardProps {
     product: Product;
-    onAddToCart: (productId: string) => void;
-    onBuyNow: (productId: string) => void;
 }
 
-const ProductCard: React.FC<ProductCardProps> = ({ product, onAddToCart, onBuyNow }) => {
+const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
     const [seller, setSeller] = useState<User | null>(null);
 
     useEffect(() => {
@@ -42,14 +39,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onAddToCart, onBuyNo
                     <span>{product.price.toFixed(2)}</span>
                 </div>
 
-                <div className="mt-auto grid grid-cols-2 gap-2">
-                    <Button onClick={() => onAddToCart(product.id)} variant="secondary" size="sm" leftIcon={<ShoppingCart size={16} />}>
-                        Add to Cart
-                    </Button>
-                    <Button onClick={() => onBuyNow(product.id)} size="sm">
-                        Buy Now
-                    </Button>
-                </div>
+                <div className="mt-auto" />
             </div>
         </div>
     );

--- a/pages/BuyerDashboard.tsx
+++ b/pages/BuyerDashboard.tsx
@@ -1,93 +1,25 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Product, Order, Role } from '../types';
-import {
-    getProducts,
-    getOrdersByBuyer,
-    addToCart as addToCartService,
-    getCart,
-    removeFromCart,
-    clearCart,
-    createOrder,
-    getProductById,
-} from '../services/firestore';
-import { useAuth } from '../contexts/AuthContext';
-import { useDashboard } from '../contexts/DashboardContext';
+import { Product } from '../types';
+import { getProducts } from '../services/firestore';
 import ProductCard from '../components/ProductCard';
-import Button from '../components/Button';
-import { Search, Repeat } from 'lucide-react';
+import { Search } from 'lucide-react';
 
 const BuyerDashboard: React.FC = () => {
-    const { user } = useAuth();
-    const { setCurrentDashboard } = useDashboard();
     const [products, setProducts] = useState<Product[]>([]);
-    const [orders, setOrders] = useState<Order[]>([]);
-    const [cart, setCart] = useState<Product[]>([]);
     const [loading, setLoading] = useState(true);
     const [searchTerm, setSearchTerm] = useState('');
     const [categoryFilter, setCategoryFilter] = useState('all');
     const [priceFilter, setPriceFilter] = useState('all');
-    const [activeTab, setActiveTab] = useState('browse');
 
     useEffect(() => {
         const load = async () => {
             const prods = await getProducts();
             setProducts(prods);
-            if (user) {
-                const ords = await getOrdersByBuyer(user.id);
-                setOrders(ords);
-                const cartData = await getCart(user.id);
-                const cartProducts = await Promise.all(cartData.productIds.map(id => getProductById(id))) as (Product | null)[];
-                setCart(cartProducts.filter(Boolean) as Product[]);
-            }
             setLoading(false);
         };
         load();
-    }, [user]);
+    }, []);
 
-    const handleAddToCart = async (productId: string) => {
-        if (user) {
-            await addToCartService(user.id, productId);
-            alert('Item added to cart!');
-            const product = await getProductById(productId);
-            if (product) {
-                setCart(prev => [...prev, product]);
-            }
-        }
-    };
-
-    const handleBuyNow = async (productId: string) => {
-        if (user) {
-            const product = await getProductById(productId);
-            if (product) {
-                await createOrder(user.id, [{ productId: product.id, price: product.price }]);
-                alert('Purchase successful!');
-                const ords = await getOrdersByBuyer(user.id);
-                setOrders(ords);
-                const cartData = await getCart(user.id);
-                const cartProducts = await Promise.all(cartData.productIds.map(id => getProductById(id))) as (Product | null)[];
-                setCart(cartProducts.filter(Boolean) as Product[]);
-            }
-        }
-    };
-
-    const handleRemoveFromCart = async (productId: string) => {
-        if (user) {
-            await removeFromCart(user.id, productId);
-            setCart(prev => prev.filter(p => p.id !== productId));
-        }
-    };
-
-    const handleCheckout = async () => {
-        if (user && cart.length > 0) {
-            const items = cart.map(p => ({ productId: p.id, price: p.price }));
-            await createOrder(user.id, items);
-            alert('Order placed!');
-            setCart([]);
-            const ords = await getOrdersByBuyer(user.id);
-            setOrders(ords);
-        }
-    };
-    
     const categories = useMemo(() => ['all', ...new Set(products.map(p => p.category))], [products]);
 
     const filteredProducts = useMemo(() => {
@@ -101,8 +33,20 @@ const BuyerDashboard: React.FC = () => {
             });
     }, [products, searchTerm, categoryFilter, priceFilter]);
 
-    const renderBrowseTab = () => (
-        <>
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    return (
+        <div>
+            <div className="mb-6">
+                <div className="flex justify-between items-center">
+                    <div>
+                        <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
+                        <p className="text-lg text-gray-600">Discover amazing products.</p>
+                    </div>
+                </div>
+            </div>
             <div className="bg-white p-4 rounded-lg shadow-sm mb-6 sticky top-[85px] z-40">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div className="relative">
@@ -135,120 +79,16 @@ const BuyerDashboard: React.FC = () => {
                     </select>
                 </div>
             </div>
-
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                 {filteredProducts.map(product => (
-                    <ProductCard key={product.id} product={product} onAddToCart={handleAddToCart} onBuyNow={handleBuyNow} />
+                    <ProductCard key={product.id} product={product} />
                 ))}
             </div>
-             {filteredProducts.length === 0 && (
+            {filteredProducts.length === 0 && (
                 <div className="col-span-full text-center py-16">
                     <p className="text-gray-500 text-xl">No products match your criteria.</p>
                 </div>
             )}
-        </>
-    );
-
-    const renderPurchasesTab = () => {
-         const getProductDetails = (productId: string) => products.find(p => p.id === productId);
-
-        return (
-            <div className="bg-white p-6 rounded-lg shadow-sm">
-                <h2 className="text-2xl font-bold text-gray-800 mb-4">Your Purchase History</h2>
-                {orders.length === 0 ? (
-                    <p className="text-gray-500">You haven't made any purchases yet.</p>
-                ) : (
-                    <div className="space-y-4">
-                        {orders.map(order => (
-                            <div key={order.id} className="border border-gray-200 rounded-lg p-4">
-                                <div className="flex justify-between items-center mb-2">
-                                    <p className="font-semibold text-gray-700">Order #{order.id.slice(-6)}</p>
-                                    <div className="text-sm text-gray-500 flex gap-2 items-center">
-                                        <span>{new Date(order.purchaseDate).toLocaleDateString()}</span>
-                                        <span className="uppercase">{order.status}</span>
-                                    </div>
-                                </div>
-                                <ul className="divide-y divide-gray-100">
-                                    {order.items.map(item => {
-                                        const product = getProductDetails(item.productId);
-                                        return product ? (
-                                            <li key={item.productId} className="py-2 flex items-center justify-between">
-                                                <div className="flex items-center gap-3">
-                                                    <img src={product.imageUrl} alt={product.name} className="h-12 w-12 rounded-md object-cover"/>
-                                                    <div>
-                                                        <p className="font-medium text-gray-800">{product.name}</p>
-                                                        <p className="text-sm text-gray-600">${item.price.toFixed(2)}</p>
-                                                    </div>
-                                                </div>
-                                            </li>
-                                        ) : null;
-                                    })}
-                                </ul>
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
-        );
-    };
-
-    const renderCartTab = () => (
-        <div className="bg-white p-6 rounded-lg shadow-sm">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4">Your Cart</h2>
-            {cart.length === 0 ? (
-                <p className="text-gray-500">Your cart is empty.</p>
-            ) : (
-                <div className="space-y-4">
-                    {cart.map(item => (
-                        <div key={item.id} className="flex justify-between items-center border border-gray-200 rounded-lg p-3">
-                            <div className="flex items-center gap-3">
-                                <img src={item.imageUrl} alt={item.name} className="h-12 w-12 rounded-md object-cover" />
-                                <div>
-                                    <p className="font-medium text-gray-800">{item.name}</p>
-                                    <p className="text-sm text-gray-600">${item.price.toFixed(2)}</p>
-                                </div>
-                            </div>
-                            <button onClick={() => handleRemoveFromCart(item.id)} className="text-red-600 text-sm">Remove</button>
-                        </div>
-                    ))}
-                    <div className="text-right">
-                        <Button onClick={handleCheckout}>Checkout</Button>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
-
-    if (loading) {
-        return <div>Loading...</div>;
-    }
-
-    return (
-        <div>
-            <div className="mb-6">
-                <div className="flex justify-between items-center">
-                    <div>
-                        <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
-                        <p className="text-lg text-gray-600">Discover and purchase amazing products.</p>
-                    </div>
-                </div>
-            </div>
-             <div className="border-b border-gray-200 mb-6">
-                <nav className="-mb-px flex space-x-8" aria-label="Tabs">
-                    <button onClick={() => setActiveTab('browse')} className={`${activeTab === 'browse' ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}>
-                        Browse Products
-                    </button>
-                    <button onClick={() => setActiveTab('cart')} className={`${activeTab === 'cart' ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}>
-                        Cart
-                    </button>
-                    <button onClick={() => setActiveTab('purchases')} className={`${activeTab === 'purchases' ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}>
-                        My Purchases
-                    </button>
-                </nav>
-            </div>
-            {activeTab === 'browse' && renderBrowseTab()}
-            {activeTab === 'cart' && renderCartTab()}
-            {activeTab === 'purchases' && renderPurchasesTab()}
         </div>
     );
 };

--- a/pages/SellerDashboard.tsx
+++ b/pages/SellerDashboard.tsx
@@ -1,35 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { Product, Order, Role, CATEGORIES, ProductStatus } from '../types';
+import { Product, CATEGORIES, ProductStatus } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import {
     getProductsBySeller,
     addProduct as addProductService,
     updateProduct as updateProductService,
     deleteProduct as deleteProductService,
-    getOrdersBySeller,
 } from '../services/firestore';
 import Button from '../components/Button';
 import Modal from '../components/Modal';
-import { Plus, Edit, Trash2, Repeat } from 'lucide-react';
-import { useDashboard } from '../contexts/DashboardContext';
+import { Plus, Edit, Trash2 } from 'lucide-react';
 
 const SellerDashboard: React.FC = () => {
     const { user } = useAuth();
-    const { setCurrentDashboard } = useDashboard();
     const [products, setProducts] = useState<Product[]>([]);
-    const [orders, setOrders] = useState<Order[]>([]);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingProduct, setEditingProduct] = useState<Product | null>(null);
     const [loading, setLoading] = useState(true);
-    const [activeTab, setActiveTab] = useState<'products' | 'sales'>('products');
 
     useEffect(() => {
         const load = async () => {
             if (user) {
                 const prods = await getProductsBySeller(user.id);
                 setProducts(prods);
-                const ords = await getOrdersBySeller(user.id);
-                setOrders(ords);
             }
             setLoading(false);
         };
@@ -81,24 +74,10 @@ const SellerDashboard: React.FC = () => {
                   <p className="text-lg text-gray-600">Manage your products and listings.</p>
                 </div>
                 <div className="flex items-center gap-2">
-                    <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}> 
-                        Add New Item
-                    </Button>
+                    <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}>Add New Item</Button>
                 </div>
             </div>
 
-            <div className="border-b border-gray-200 mb-6">
-                <nav className="-mb-px flex space-x-8" aria-label="Tabs">
-                    <button onClick={() => setActiveTab('products')} className={`${activeTab === 'products' ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}>
-                        Products
-                    </button>
-                    <button onClick={() => setActiveTab('sales')} className={`${activeTab === 'sales' ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}>
-                        Sales
-                    </button>
-                </nav>
-            </div>
-
-            {activeTab === 'products' && (
             <div className="bg-white shadow-sm rounded-lg">
                 <div className="overflow-x-auto">
                     <table className="min-w-full divide-y divide-gray-200">
@@ -108,9 +87,7 @@ const SellerDashboard: React.FC = () => {
                                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
                                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
                                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                                <th scope="col" className="relative px-6 py-3">
-                                    <span className="sr-only">Actions</span>
-                                </th>
+                                <th scope="col" className="relative px-6 py-3"><span className="sr-only">Actions</span></th>
                             </tr>
                         </thead>
                         <tbody className="bg-white divide-y divide-gray-200">
@@ -151,35 +128,10 @@ const SellerDashboard: React.FC = () => {
                 {products.length === 0 && (
                     <div className="text-center py-16">
                         <p className="text-gray-500 text-xl">You haven't listed any products yet.</p>
-                        <Button onClick={() => handleOpenModal()} leftIcon={<Plus />} className="mt-4">
-                            List Your First Item
-                        </Button>
+                        <Button onClick={() => handleOpenModal()} leftIcon={<Plus />} className="mt-4">List Your First Item</Button>
                     </div>
                  )}
             </div>
-            )}
-
-            {activeTab === 'sales' && (
-            <div className="bg-white shadow-sm rounded-lg p-6">
-                <h2 className="text-xl font-bold mb-4">Items Sold</h2>
-                {orders.length === 0 ? (
-                    <p className="text-gray-500">No sales yet.</p>
-                ) : (
-                    <ul className="divide-y divide-gray-100">
-                        {orders.map(order => (
-                            <li key={order.id} className="py-2">
-                                <p className="font-medium">Order #{order.id.slice(-6)} - {new Date(order.purchaseDate).toLocaleDateString()}</p>
-                                <ul className="pl-4 list-disc">
-                                    {order.items.map(item => (
-                                        <li key={item.productId}>{item.productId} - ${item.price.toFixed(2)}</li>
-                                    ))}
-                                </ul>
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-            )}
 
             {isModalOpen && (
                 <ProductFormModal
@@ -273,6 +225,5 @@ const ProductFormModal: React.FC<ProductFormModalProps> = ({ isOpen, onClose, on
         </Modal>
     );
 };
-
 
 export default SellerDashboard;

--- a/types.ts
+++ b/types.ts
@@ -8,12 +8,6 @@ export enum ProductStatus {
     LIVE = 'live',
 }
 
-export enum OrderStatus {
-    PENDING = 'pending',
-    PAID = 'paid',
-    SHIPPED = 'shipped',
-    DELIVERED = 'delivered',
-}
 
 export const CATEGORIES = [
     'Electronics',
@@ -47,22 +41,6 @@ export interface Product {
     status: ProductStatus;
 }
 
-export interface Order {
-    id: string;
-    buyerId: string;
-    items: { productId: string; price: number }[];
-    purchaseDate: string;
-    status: OrderStatus;
-}
-
-export interface Cart {
-    userId: string;
-    productIds: string[];
-}
-
-export interface CartItem {
-    productId: string;
-}
 
 export interface Message {
     id: string;


### PR DESCRIPTION
## Summary
- strip Add to Cart and Buy Now features from product card
- streamline buyer dashboard to only browse items
- simplify seller dashboard and remove sales tab
- delete cart/order utilities from firestore service
- drop cart and order types

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686392a8c5cc833082aef0b46068e9ac