### PR TITLE
Add messaging management and location picker

### DIFF
--- a/components/LocationPicker.tsx
+++ b/components/LocationPicker.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef } from 'react';
+
+declare global {
+  interface Window {
+    google: any;
+  }
+}
+
+interface LocationPickerProps {
+  address: string;
+  lat: string;
+  lng: string;
+  onChange: (address: string, lat: string, lng: string) => void;
+}
+
+const loadScript = (src: string) => {
+  return new Promise<void>((resolve) => {
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve());
+      if ((existing as HTMLScriptElement).readyState === 'complete') resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    document.body.appendChild(script);
+  });
+};
+
+const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onChange }) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}&libraries=places`;
+    let map: google.maps.Map | null = null;
+    let marker: google.maps.Marker | null = null;
+    loadScript(src).then(() => {
+      if (!mapRef.current || !inputRef.current || !window.google) return;
+      const center = {
+        lat: parseFloat(lat || '0') || 0,
+        lng: parseFloat(lng || '0') || 0,
+      };
+      map = new window.google.maps.Map(mapRef.current, {
+        center,
+        zoom: 8,
+      });
+      marker = new window.google.maps.Marker({ map });
+      if (lat && lng) {
+        marker.setPosition(center);
+      }
+      const autocomplete = new window.google.maps.places.Autocomplete(inputRef.current!);
+      if (address) inputRef.current!.value = address;
+      autocomplete.addListener('place_changed', () => {
+        const place = autocomplete.getPlace();
+        if (!place.geometry) return;
+        const loc = place.geometry.location;
+        const addr = place.formatted_address || '';
+        onChange(addr, loc.lat().toString(), loc.lng().toString());
+        map!.setCenter(loc);
+        marker!.setPosition(loc);
+      });
+    });
+  }, []);
+
+  return (
+    <div>
+      <input ref={inputRef} type="text" className="mt-1 mb-2 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
+      <div ref={mapRef} style={{ height: '200px', width: '100%' }} />
+    </div>
+  );
+};
+
+export default LocationPicker;

--- a/pages/BuyerDashboard.tsx
+++ b/pages/BuyerDashboard.tsx
@@ -2,9 +2,11 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Product } from '../types';
 import { getProducts } from '../services/firestore';
 import ProductCard from '../components/ProductCard';
+import Button from '../components/Button';
 import { Search } from 'lucide-react';
 import Modal from '../components/Modal';
 import MessagingPage from './MessagingPage';
+import MessagesScreen from './MessagesScreen';
 
 const toRad = (value: number) => (value * Math.PI) / 180;
 const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number) => {
@@ -28,6 +30,7 @@ const BuyerDashboard: React.FC = () => {
     const [distanceFilter, setDistanceFilter] = useState('all');
     const [userLocation, setUserLocation] = useState<{lat: number; lng: number} | null>(null);
     const [messageInfo, setMessageInfo] = useState<{sellerId: string; productId: string} | null>(null);
+    const [showMessages, setShowMessages] = useState(false);
 
     useEffect(() => {
         const load = async () => {
@@ -84,6 +87,7 @@ const BuyerDashboard: React.FC = () => {
                         <h1 className="text-4xl font-bold text-gray-900">Buyer Dashboard</h1>
                         <p className="text-lg text-gray-600">Discover amazing products.</p>
                     </div>
+                    <Button onClick={() => setShowMessages(true)}>Messages</Button>
                 </div>
             </div>
             <div className="bg-white p-4 rounded-lg shadow-sm mb-6 sticky top-[85px] z-40">
@@ -142,6 +146,11 @@ const BuyerDashboard: React.FC = () => {
             {messageInfo && (
                 <Modal isOpen={true} onClose={() => setMessageInfo(null)} title="Message Seller">
                     <MessagingPage otherUserId={messageInfo.sellerId} productId={messageInfo.productId} />
+                </Modal>
+            )}
+            {showMessages && (
+                <Modal isOpen={true} onClose={() => setShowMessages(false)} title="Messages">
+                    <MessagesScreen />
                 </Modal>
             )}
         </div>

--- a/pages/MessagesScreen.tsx
+++ b/pages/MessagesScreen.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { getMessagesByUser, getUserById } from '../services/firestore';
+import { Message, User } from '../types';
+import Button from '../components/Button';
+import Modal from '../components/Modal';
+import MessagingPage from './MessagingPage';
+
+const MessagesScreen: React.FC = () => {
+  const { user } = useAuth();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [openChat, setOpenChat] = useState<string | null>(null);
+  const [otherUser, setOtherUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (user) {
+        const msgs = await getMessagesByUser(user.id);
+        setMessages(msgs);
+      }
+    };
+    load();
+  }, [user]);
+
+  const threads = useMemo(() => {
+    const map = new Map<string, Message>();
+    messages.forEach((m) => {
+      const other = m.fromId === user?.id ? m.toId : m.fromId;
+      const existing = map.get(other);
+      if (!existing || new Date(existing.createdAt) < new Date(m.createdAt)) {
+        map.set(other, m);
+      }
+    });
+    return Array.from(map.entries());
+  }, [messages, user]);
+
+  const openThread = async (otherId: string) => {
+    setOpenChat(otherId);
+    const usr = await getUserById(otherId);
+    setOtherUser(usr);
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Messages</h2>
+      <div className="space-y-2">
+        {threads.map(([otherId, msg]) => (
+          <div key={otherId} className="flex justify-between items-center bg-white p-3 rounded-md shadow-sm">
+            <span>{otherId}</span>
+            <Button size="sm" onClick={() => openThread(otherId)}>Open</Button>
+          </div>
+        ))}
+        {threads.length === 0 && <p>No messages yet.</p>}
+      </div>
+
+      {openChat && (
+        <Modal isOpen={true} onClose={() => setOpenChat(null)} title={otherUser ? `Chat with ${otherUser.name}` : 'Conversation'}>
+          <MessagingPage otherUserId={openChat} />
+        </Modal>
+      )}
+    </div>
+  );
+};
+
+export default MessagesScreen;

--- a/pages/MessagingPage.tsx
+++ b/pages/MessagingPage.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
-import { getMessages, sendMessage } from '../services/firestore';
+import {
+  getMessages,
+  sendMessage,
+  editMessage,
+  deleteMessage,
+} from '../services/firestore';
 import { Message } from '../types';
 import Button from '../components/Button';
 
@@ -13,6 +18,8 @@ const MessagingPage: React.FC<MessagingPageProps> = ({ otherUserId, productId })
   const { user } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [text, setText] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState('');
 
   useEffect(() => {
     const load = async () => {
@@ -39,18 +46,88 @@ const MessagingPage: React.FC<MessagingPageProps> = ({ otherUserId, productId })
     }
   };
 
+  const handleEditSave = async () => {
+    if (editingId && editText.trim()) {
+      await editMessage(editingId, editText.trim());
+      setEditingId(null);
+      setEditText('');
+      if (user) {
+        const msgs = await getMessages(user.id, otherUserId);
+        setMessages(msgs);
+      }
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('Delete this message?')) {
+      await deleteMessage(id);
+      if (user) {
+        const msgs = await getMessages(user.id, otherUserId);
+        setMessages(msgs);
+      }
+    }
+  };
+
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm">
       <div className="space-y-2 mb-4">
-        {messages.map(m => (
-          <div key={m.id} className={`p-2 rounded-md ${m.fromId === user?.id ? 'bg-primary-100 text-right' : 'bg-gray-100'}`}>{m.text}</div>
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            className={`relative p-2 rounded-md ${m.fromId === user?.id ? 'bg-primary-100 text-right' : 'bg-gray-100'}`}
+          >
+            {editingId === m.id ? (
+              <div className="flex gap-2">
+                <input
+                  className="flex-grow border border-gray-300 rounded-md px-2"
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                />
+                <Button size="sm" onClick={handleEditSave}>Save</Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    setEditingId(null);
+                    setEditText('');
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <>
+                <span className={m.deleted ? 'line-through text-gray-400' : ''}>{m.text}</span>
+                {m.editedAt && !m.deleted && (
+                  <span className="ml-1 text-xs text-gray-500">(edited)</span>
+                )}
+                {m.deleted && <span className="ml-1 text-xs text-gray-500">(deleted)</span>}
+                {m.fromId === user?.id && !m.deleted && (
+                  <span className="ml-2 text-xs text-gray-500">
+                    <button
+                      className="underline mr-1"
+                      onClick={() => {
+                        setEditingId(m.id);
+                        setEditText(m.text);
+                      }}
+                    >
+                      Edit
+                    </button>
+                    <button className="underline text-red-600" onClick={() => handleDelete(m.id)}>
+                      Delete
+                    </button>
+                  </span>
+                )}
+              </>
+            )}
+          </div>
         ))}
       </div>
       <div className="flex gap-2">
         <input
           type="text"
           value={text}
-          onChange={e => setText(e.target.value)}
+          onChange={(e) => setText(e.target.value)}
           className="flex-grow border border-gray-300 rounded-md px-3 py-2 focus:outline-none"
         />
         <Button onClick={handleSend}>Send</Button>

--- a/pages/SellerDashboard.tsx
+++ b/pages/SellerDashboard.tsx
@@ -10,6 +10,8 @@ import {
 import Button from '../components/Button';
 import Modal from '../components/Modal';
 import { Plus, Edit, Trash2 } from 'lucide-react';
+import MessagesScreen from './MessagesScreen';
+import LocationPicker from '../components/LocationPicker';
 
 const SellerDashboard: React.FC = () => {
     const { user } = useAuth();
@@ -17,6 +19,7 @@ const SellerDashboard: React.FC = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingProduct, setEditingProduct] = useState<Product | null>(null);
     const [loading, setLoading] = useState(true);
+    const [showMessages, setShowMessages] = useState(false);
 
     useEffect(() => {
         const load = async () => {
@@ -74,6 +77,7 @@ const SellerDashboard: React.FC = () => {
                   <p className="text-lg text-gray-600">Manage your products and listings.</p>
                 </div>
                 <div className="flex items-center gap-2">
+                    <Button onClick={() => setShowMessages(true)}>Messages</Button>
                     <Button onClick={() => handleOpenModal()} leftIcon={<Plus />}>Add New Item</Button>
                 </div>
             </div>
@@ -140,6 +144,11 @@ const SellerDashboard: React.FC = () => {
                     onSave={handleSaveProduct}
                     product={editingProduct}
                 />
+            )}
+            {showMessages && (
+                <Modal isOpen={true} onClose={() => setShowMessages(false)} title="Messages">
+                    <MessagesScreen />
+                </Modal>
             )}
         </div>
     );
@@ -215,18 +224,17 @@ const ProductFormModal: React.FC<ProductFormModalProps> = ({ isOpen, onClose, on
                     <input type="text" value={imageUrl} onChange={(e) => setImageUrl(e.target.value)} className="mt-2 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
                 </div>
                 <div>
-                    <label className="block text-sm font-medium text-gray-700">Location Address</label>
-                    <input type="text" value={address} onChange={(e) => setAddress(e.target.value)} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium text-gray-700">Latitude</label>
-                        <input type="number" value={lat} onChange={(e) => setLat(e.target.value)} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium text-gray-700">Longitude</label>
-                        <input type="number" value={lng} onChange={(e) => setLng(e.target.value)} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
-                    </div>
+                    <label className="block text-sm font-medium text-gray-700">Location</label>
+                    <LocationPicker
+                        address={address}
+                        lat={lat}
+                        lng={lng}
+                        onChange={(a, la, lo) => {
+                            setAddress(a);
+                            setLat(la);
+                            setLng(lo);
+                        }}
+                    />
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700">Status</label>

--- a/types.ts
+++ b/types.ts
@@ -54,4 +54,8 @@ export interface Message {
     text: string;
     productId?: string;
     createdAt: string;
+    editedAt?: string;
+    history?: string[];
+    deleted?: boolean;
+    deletedAt?: string;
 }


### PR DESCRIPTION
## Summary
- extend `Message` type to track edits and deletions
- support editing/deleting messages in `MessagingPage`
- implement Firestore helpers for message management
- add `MessagesScreen` to show conversations
- expose Messages screen in buyer and seller dashboards
- add Google Maps based `LocationPicker` for sellers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863be85e5c88330a065ea8763ea976e