### PR TITLE
Fix Google Maps init errors

### DIFF
--- a/components/LocationPicker.tsx
+++ b/components/LocationPicker.tsx
@@ -46,6 +46,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onCh
     let map: any = null;
     let marker: any = null;
     const init = async () => {
+      try {
       await loadScript(src);
       if (!mapRef.current || !inputRef.current || !window.google?.maps) return;
       // ensure libraries are loaded when using loading=async
@@ -57,6 +58,10 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onCh
         MapClass = window.google.maps.Map;
         MarkerClass = window.google.maps.Marker;
         AutocompleteClass = window.google.maps.places.Autocomplete;
+      }
+      if (!MapClass || !MarkerClass || !AutocompleteClass) {
+        console.error('Google Maps libraries failed to load');
+        return;
       }
       const center = {
         lat: parseFloat(lat || '0') || 0,
@@ -81,6 +86,9 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onCh
         map!.setCenter(loc);
         marker!.setPosition(loc);
       });
+      } catch (err) {
+        console.error('Failed to initialize Google Maps', err);
+      }
     };
     init();
   }, []);


### PR DESCRIPTION
## Summary
- handle missing Google Maps libraries gracefully in `LocationPicker`

## Testing
- `npx tsc --noEmit` *(fails: cannot find module 'path' and hundreds of TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863c896c878833085a15e374f45375b