### PR TITLE
Fix location picker and add seller profile page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import LoginPage from './pages/LoginPage';
 import BuyerDashboard from './pages/BuyerDashboard';
 import SellerDashboard from './pages/SellerDashboard';
 import ProductDetailPage from './pages/ProductDetailPage';
+import SellerProfilePage from './pages/SellerProfilePage';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import Modal from './components/Modal';
@@ -78,6 +79,7 @@ const Main: React.FC = () => {
       <main className="flex-grow container mx-auto px-4 py-8">
         <Routes>
           <Route path="/product/:id" element={<ProductDetailPage />} />
+          <Route path="/seller/:id" element={<SellerProfilePage />} />
           <Route path="*" element={renderHome()} />
         </Routes>
       </main>

--- a/components/LocationPicker.tsx
+++ b/components/LocationPicker.tsx
@@ -46,8 +46,8 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onCh
         await loadGoogleMaps(apiKey);
 
         const { Map } = (await window.google.maps.importLibrary('maps')) as google.maps.MapsLibrary;
-        const { AdvancedMarkerElement } = (await window.google.maps.importLibrary('marker')) as google.maps.MarkerLibrary;
-        const { PlaceAutocompleteElement } = (await window.google.maps.importLibrary('places')) as google.maps.PlacesLibrary;
+        const { Marker } = (await window.google.maps.importLibrary('marker')) as google.maps.MarkerLibrary;
+        await window.google.maps.importLibrary('places');
 
         if (!mapRef.current || !inputRef.current) return;
 
@@ -62,18 +62,15 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ address, lat, lng, onCh
           mapId,
         });
 
-        const marker = new AdvancedMarkerElement({
+        const marker = new Marker({
           map,
           position: lat && lng ? center : undefined,
         });
-
-        const autocomplete = new PlaceAutocompleteElement({
-          inputElement: inputRef.current,
-        });
+        const autocomplete = new window.google.maps.places.Autocomplete(inputRef.current);
 
         if (address) inputRef.current.value = address;
 
-        autocomplete.addEventListener('gmp-placechange', () => {
+        autocomplete.addListener('place_changed', () => {
           const place = autocomplete.getPlace();
           if (!place?.geometry?.location) return;
 

--- a/pages/BuyerDashboard.tsx
+++ b/pages/BuyerDashboard.tsx
@@ -7,6 +7,7 @@ import { Search } from 'lucide-react';
 import Modal from '../components/Modal';
 import MessagingPage from './MessagingPage';
 import MessagesScreen from './MessagesScreen';
+import LocationPicker from '../components/LocationPicker';
 
 const toRad = (value: number) => (value * Math.PI) / 180;
 const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number) => {
@@ -29,6 +30,10 @@ const BuyerDashboard: React.FC = () => {
     const [priceFilter, setPriceFilter] = useState('all');
     const [distanceFilter, setDistanceFilter] = useState('all');
     const [userLocation, setUserLocation] = useState<{lat: number; lng: number} | null>(null);
+    const [locationAddress, setLocationAddress] = useState('');
+    const [locationLat, setLocationLat] = useState('');
+    const [locationLng, setLocationLng] = useState('');
+    const [showLocationModal, setShowLocationModal] = useState(false);
     const [messageInfo, setMessageInfo] = useState<{sellerId: string; productId: string} | null>(null);
     const [showMessages, setShowMessages] = useState(false);
 
@@ -45,6 +50,8 @@ const BuyerDashboard: React.FC = () => {
         if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition((pos) => {
                 setUserLocation({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+                setLocationLat(pos.coords.latitude.toString());
+                setLocationLng(pos.coords.longitude.toString());
             });
         }
     }, []);
@@ -91,7 +98,7 @@ const BuyerDashboard: React.FC = () => {
                 </div>
             </div>
             <div className="bg-white p-4 rounded-lg shadow-sm mb-6 sticky top-[85px] z-40">
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
                     <div className="relative">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
                         <input
@@ -130,11 +137,20 @@ const BuyerDashboard: React.FC = () => {
                         <option value="5">&lt; 5 km</option>
                         <option value="10">&lt; 10 km</option>
                     </select>
+                    <Button variant="secondary" onClick={() => setShowLocationModal(true)} className="w-full">
+                        {userLocation ? 'Change Location' : 'Set Location'}
+                    </Button>
                 </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                 {filteredProducts.map(p => (
-                    <ProductCard key={p.product.id} product={p.product} distanceKm={p.distance} onMessageSeller={(sellerId, productId) => setMessageInfo({ sellerId, productId })} />
+                    <ProductCard
+                        key={p.product.id}
+                        product={p.product}
+                        distanceKm={p.distance}
+                        onMessageSeller={(sellerId, productId) => setMessageInfo({ sellerId, productId })}
+                        onCategoryClick={(cat) => setCategoryFilter(cat)}
+                    />
                 ))}
             </div>
             {filteredProducts.length === 0 && (
@@ -151,6 +167,31 @@ const BuyerDashboard: React.FC = () => {
             {showMessages && (
                 <Modal isOpen={true} onClose={() => setShowMessages(false)} title="Messages">
                     <MessagesScreen />
+                </Modal>
+            )}
+            {showLocationModal && (
+                <Modal isOpen={true} onClose={() => setShowLocationModal(false)} title="Select Location">
+                    <div className="p-4 space-y-4">
+                        <LocationPicker
+                            address={locationAddress}
+                            lat={locationLat}
+                            lng={locationLng}
+                            onChange={(a, la, lo) => {
+                                setLocationAddress(a);
+                                setLocationLat(la);
+                                setLocationLng(lo);
+                            }}
+                        />
+                        <div className="flex justify-end gap-2">
+                            <Button variant="secondary" onClick={() => setShowLocationModal(false)}>Cancel</Button>
+                            <Button onClick={() => {
+                                if (locationLat && locationLng) {
+                                    setUserLocation({ lat: parseFloat(locationLat), lng: parseFloat(locationLng) });
+                                }
+                                setShowLocationModal(false);
+                            }}>Save</Button>
+                        </div>
+                    </div>
                 </Modal>
             )}
         </div>

--- a/pages/SellerProfilePage.tsx
+++ b/pages/SellerProfilePage.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getUserById, getProductsBySeller } from '../services/firestore';
+import { User, Product, ProductStatus } from '../types';
+import ProductCard from '../components/ProductCard';
+import Button from '../components/Button';
+import Modal from '../components/Modal';
+import MessagingPage from './MessagingPage';
+
+const SellerProfilePage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [seller, setSeller] = useState<User | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showMessage, setShowMessage] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      if (id) {
+        const usr = await getUserById(id);
+        setSeller(usr);
+        const prods = await getProductsBySeller(id);
+        setProducts(prods.filter(p => p.status === ProductStatus.LIVE));
+      }
+      setLoading(false);
+    };
+    load();
+  }, [id]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!seller) {
+    return <div>Seller not found.</div>;
+  }
+
+  return (
+    <div>
+      <div className="bg-white rounded-lg shadow p-6 mb-4 flex items-center gap-4">
+        <img
+          src={seller.profilePicUrl}
+          alt={seller.name}
+          className="w-16 h-16 rounded-full object-cover"
+        />
+        <div className="flex-grow">
+          <h1 className="text-2xl font-bold">{seller.name}</h1>
+        </div>
+        <Button onClick={() => setShowMessage(true)}>Message Seller</Button>
+      </div>
+
+      <h2 className="text-xl font-semibold mb-2">Listings</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {products.map((p) => (
+          <ProductCard key={p.id} product={p} />
+        ))}
+      </div>
+
+      {showMessage && (
+        <Modal
+          isOpen={true}
+          onClose={() => setShowMessage(false)}
+          title={`Message ${seller.name}`}
+        >
+          <MessagingPage otherUserId={seller.id} />
+        </Modal>
+      )}
+    </div>
+  );
+};
+
+export default SellerProfilePage;


### PR DESCRIPTION
## Summary
- add SellerProfilePage for viewing seller info and messaging them
- make entire ProductCard clickable with new features
- fix Google Maps autocomplete usage
- allow buyers to set location manually
- route to new seller profile page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863db8f9e9883308124211fc284fa67